### PR TITLE
drop logback dependency in favor of only using slf4j-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ You can run your computations in any type `F[_]`.
 
 * Java 6 or higher
 * Scala 2.11 or 2.12
-* [Logback](http://logback.qos.ch) backend compatible with [SLF4J](https://www.slf4j.org/)
 
 ## Getting Logger4s ##
 

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val V = new {
   val macroParadiseVersion = "2.1.1"
   val kindProjectorVersion = "0.9.9"
   val loggingScalaVersion = "3.5.0"
-  val logbackClassicVersion = "1.2.3"
+  val slf4jApiVersion = "1.7.25"
   val json4sVersion = "3.6.4"
   val mockitoVersion = "1.10.19"
   val scalazZIOVersion = "0.6.3"
@@ -78,7 +78,7 @@ lazy val core = crossProject(JVMPlatform)
   .settings(buildSettings)
   .settings(commonDependencies)
   .jvmSettings(libraryDependencies ++= Seq(
-    "ch.qos.logback" % "logback-classic" % V.logbackClassicVersion
+    "org.slf4j" % "slf4j-api" % V.slf4jApiVersion
   ))
 
 lazy val coreJVM = core.jvm


### PR DESCRIPTION
This PR drops the logback dependency in favor of `slf4j-api` `1.7.25` which provides the underlying interface of `org.slf4j.LoggerFactory`. No code changes are required since everything already uses that interface.

This change allows consumers of `logger4s` to choose a different logging back-end.
In particular this avoids a common problem when a project brings in multiple components with differing logging framework, resulting in [multiple bindings problem](http://www.slf4j.org/codes.html#multiple_bindings).

This change also allows libraries to depend on `logger4s` without propagating a potentially unwanted logback dependency. 
